### PR TITLE
Add bookmark tags as RSS categories

### DIFF
--- a/src/Handler/Notes.hs
+++ b/src/Handler/Notes.hs
@@ -153,6 +153,7 @@ noteToRssEntry usernamep (Entity entryId entry) =
             , feedEntryTitle = (noteTitle entry)
             , feedEntryContent =  (toHtml (noteText entry))
             , feedEntryEnclosure = Nothing
+            , feedEntryCategories = []
             }
 
 getNotesFeedR :: UserNameP -> Handler RepRss

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,10 @@
 resolver: lts-14.3
 # allow-newer: true
-extra-deps: 
+packages:
+- '.'
+extra-deps:
 - ekg-0.4.0.15
 - ekg-json-0.1.0.6
 - monad-metrics-0.2.1.4
 - wai-middleware-metrics-0.2.4
-packages:
-- '.'
+- yesod-newsfeed-1.7.0.0

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -32,6 +32,13 @@ packages:
       sha256: 99366b831109417cd8e739fb45e9fd214cb79f28a507f8154e5528120042d0ac
   original:
     hackage: wai-middleware-metrics-0.2.4
+- completed:
+    hackage: yesod-newsfeed-1.7.0.0@sha256:ba49f9af47fe96c521ed889bf041c559b4bddb60a81f385449f7557f8f4aaef2,1345
+    pantry-tree:
+      size: 488
+      sha256: 96027436cc6dc07bca3f691f2d17a5b3993e980f73076c7b1b4d9c5c3ac5cb86
+  original:
+    hackage: yesod-newsfeed-1.7.0.0
 snapshots:
 - completed:
     size: 523878


### PR DESCRIPTION
Put bookmarks tags into RSS categories.

Unfortunately, `yesod-newsfeed` didn't support categories so I added it in version `1.7.0.0`.
For some reason, `yesod` disappeared from stackage nightlies just after LTS 14.7.

So I changed the `stack.yaml` to directly use `yesod-newsfeed-1.7.0.0` from hackage.
Another option is to wait for it to appear in some LTS (hopefully they should fix the yesod disappearance) and to just bump the lts in `stack.yaml`.