### PR TITLE
API key auth

### DIFF
--- a/espial.cabal
+++ b/espial.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
 
@@ -163,6 +163,7 @@ library
       aeson >=1.4
     , attoparsec
     , base >=4.8.2.0 && <4.9 || >=4.9.1.0 && <5
+    , base64
     , bcrypt >=0.0.8
     , blaze-html >=0.9 && <1.0
     , bytestring >=0.9 && <0.11
@@ -173,6 +174,7 @@ library
     , conduit >=1.0 && <2.0
     , connection
     , containers
+    , cryptohash-sha256
     , data-default
     , directory >=1.1 && <1.4
     , entropy
@@ -273,6 +275,7 @@ executable espial
       aeson >=1.4
     , attoparsec
     , base >=4.8.2.0 && <4.9 || >=4.9.1.0 && <5
+    , base64
     , bcrypt >=0.0.8
     , blaze-html >=0.9 && <1.0
     , bytestring >=0.9 && <0.11
@@ -283,6 +286,7 @@ executable espial
     , conduit >=1.0 && <2.0
     , connection
     , containers
+    , cryptohash-sha256
     , data-default
     , directory >=1.1 && <1.4
     , entropy
@@ -380,6 +384,7 @@ executable migration
       aeson >=1.4
     , attoparsec
     , base >=4.8.2.0 && <4.9 || >=4.9.1.0 && <5
+    , base64
     , bcrypt >=0.0.8
     , blaze-html >=0.9 && <1.0
     , bytestring >=0.9 && <0.11
@@ -390,6 +395,7 @@ executable migration
     , conduit >=1.0 && <2.0
     , connection
     , containers
+    , cryptohash-sha256
     , data-default
     , directory >=1.1 && <1.4
     , entropy
@@ -493,6 +499,7 @@ test-suite test
       aeson >=1.4
     , attoparsec
     , base >=4.8.2.0 && <4.9 || >=4.9.1.0 && <5
+    , base64
     , bcrypt >=0.0.8
     , blaze-html >=0.9 && <1.0
     , bytestring >=0.9 && <0.11
@@ -503,6 +510,7 @@ test-suite test
     , conduit >=1.0 && <2.0
     , connection
     , containers
+    , cryptohash-sha256
     , data-default
     , directory >=1.1 && <1.4
     , entropy

--- a/package.yaml
+++ b/package.yaml
@@ -141,6 +141,8 @@ dependencies:
 - parser-combinators
 - html-entities
 - connection
+- base64
+- cryptohash-sha256
 
 # The library contains all of our application code. The executable
 # defined below is just a thin wrapper.

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -34,7 +34,7 @@ User json
   Id Int64
   name Text
   passwordHash BCrypt
-  apiToken Text Maybe
+  apiToken HashedApiKey Maybe
   privateDefault Bool
   archiveDefault Bool
   privacyLock Bool
@@ -158,6 +158,10 @@ authenticatePassword username password = do
 getUserByName :: UserNameP -> DB (Maybe (Entity User))
 getUserByName (UserNameP uname) =
   selectFirst [UserName CP.==. uname] []
+
+getApiKeyUser :: ApiKey -> DB (Maybe (Entity User))
+getApiKeyUser apiKey =
+  selectFirst [UserApiToken CP.==. Just (hashApiKey apiKey)] []
 
 -- returns a list of pair of bookmark with tags merged into a string
 bookmarksTagsQuery


### PR DESCRIPTION
#### Motivation:
Occasionally I want to save an article from my feed reader to Espial to read it later. The feed reader I use ([Miniflux](https://github.com/miniflux/v2)) provides integrations with different such services, and I am trying to add an Espial integration as well. Unfortunately, Espial uses cookie-based authentication throughout the app and as such makes heavy use of sessions, making it hard to consume by third-party services. This PR adds an alternative API key auth mechanism, to be allowed for selectively for specific routes. For such routes, an authorization header of the form `Authorization: ApiKey <API-KEY>` could be used to gain access to the resource. API keys are managed through the usual migration utility with two new commands: `createapikey` and `deleteapikey`.

For example:
```bash
$ cabal run migration -- createapikey --conn espial.sqlite3 --userName myuser
"-XmazfDccY1l-tNCjq_0Iy6RnQaCWrvkvA253X1g2As="

$ http -v POST localhost:3000/api/add url=https://example.com title="Example" Authorization:"ApiKey -XmazfDccY1l-tNCjq_0Iy6RnQaCWrvkvA253X1g2As="

POST /api/add HTTP/1.1
Accept: application/json, */*;q=0.5
Accept-Encoding: gzip, deflate, br
Authorization: ApiKey -XmazfDccY1l-tNCjq_0Iy6RnQaCWrvkvA253X1g2As=
Connection: keep-alive
Content-Length: 46
Content-Type: application/json
Host: localhost:3000
User-Agent: HTTPie/3.0.2

{
    "title": "Example",
    "url": "https://example.com"
}


HTTP/1.1 201 Created
Content-Length: 1
Content-Type: application/json; charset=utf-8
Date: Wed, 13 Apr 2022 19:39:54 GMT
Server: Warp/3.3.19
Set-Cookie: _SESSION=FgPaaVWGrNO/fWGDisxgRtYi7hwn10X2ZrxWqHaew0NLegHM3i5eJKLmXrpt4FAGxF0mc3fPzQle4Bvju1Hs1bJznd3Ywkj5Aa1g1uJmvEACTfcAxhvaaaUJiD40E1qCdBj6nXWL+4FDrdwJu0QJpYoNyl+EfffPtpwprTxirK+upfk2htQ=; Path=/; Expires=Wed, 20-Apr-2022 19:39:54 GMT; HttpOnly
Vary: Accept-Encoding
Vary: Accept, Accept-Language
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block

6

```

#### Implementation details:
- API keys are generated by reading 32 random bytes and encoding it as base64
- Keys are stored in database in hashed form (SHA-256)
- The hash is unsalted, since we want to be able to lookup a user by a given API key (I don't think this poses to be a problem since the key itself is random and pretty long to be vulnerable to brute forcing, though alternatives could be discussed)
- CSRF middleware is disabled if an authorization header is provided and the requested route allows for API key auth

I think the implementation doesn't expose any vulnerabilities, though I am not too familiar with the Yesod way of doing things and security isn't my strongest suite, so I would appreciate feedback regarding these choices.