### PR TITLE
Migrate to GHC 9.0

### DIFF
--- a/espial.cabal
+++ b/espial.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.34.7.
 --
 -- see: https://github.com/sol/hpack
 
@@ -209,7 +209,7 @@ library
     , vector
     , wai
     , wai-extra >=3.0 && <3.2
-    , wai-logger >=2.2 && <2.4
+    , wai-logger
     , warp >=3.0 && <3.4
     , yaml >=0.8 && <0.12
     , yesod >=1.6 && <1.8
@@ -322,7 +322,7 @@ executable espial
     , vector
     , wai
     , wai-extra >=3.0 && <3.2
-    , wai-logger >=2.2 && <2.4
+    , wai-logger
     , warp >=3.0 && <3.4
     , yaml >=0.8 && <0.12
     , yesod >=1.6 && <1.8
@@ -433,7 +433,7 @@ executable migration
     , vector
     , wai
     , wai-extra >=3.0 && <3.2
-    , wai-logger >=2.2 && <2.4
+    , wai-logger
     , warp >=3.0 && <3.4
     , yaml >=0.8 && <0.12
     , yesod >=1.6 && <1.8
@@ -547,7 +547,7 @@ test-suite test
     , vector
     , wai
     , wai-extra >=3.0 && <3.2
-    , wai-logger >=2.2 && <2.4
+    , wai-logger
     , warp >=3.0 && <3.4
     , yaml >=0.8 && <0.12
     , yesod >=1.6 && <1.8

--- a/package.yaml
+++ b/package.yaml
@@ -112,7 +112,7 @@ dependencies:
 - conduit >=1.0 && <2.0
 - monad-logger >=0.3 && <0.4
 - fast-logger >=2.2 && <4
-- wai-logger >=2.2 && <2.4
+- wai-logger
 - file-embed
 - safe
 - unordered-containers

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -221,6 +221,7 @@ dbAuthPluginName = "db"
 dbAuthPlugin :: AuthPlugin App
 dbAuthPlugin = AuthPlugin dbAuthPluginName dbDispatch dbLoginHandler
   where
+    dbDispatch :: Text -> [Text] -> AuthHandler App TypedContent
     dbDispatch "POST" ["login"] = dbPostLoginR >>= sendResponse
     dbDispatch _ _ = notFound
     dbLoginHandler toParent = do
@@ -259,7 +260,7 @@ authenticateCreds Creds {..} = do
   muser <-
     case credsPlugin of
       p | p == dbAuthPluginName -> liftHandler $ runDB $
-        join <$> mapM (authenticatePassword credsIdent) (lookup "password" credsExtra)
+        join <$> mapM (\pwd -> authenticatePassword credsIdent pwd) (lookup "password" credsExtra)
       _ -> pure Nothing
   case muser of
     Nothing -> pure (UserError InvalidUsernamePass)

--- a/src/Handler/Archive.hs
+++ b/src/Handler/Archive.hs
@@ -50,7 +50,7 @@ archiveBookmarkUrl kbid url =
         manager <- getArchiveManager
         res <- liftIO $ NH.httpLbs req manager
         let status = NH.responseStatus res
-        let updateArchiveUrl = runDB . updateBookmarkArchiveUrl userId kbid . Just
+        let updateArchiveUrl url' = runDB $ updateBookmarkArchiveUrl userId kbid $ Just url'
             headers = NH.responseHeaders res
         case status of
           s | s == NH.status200 ->

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -6,6 +6,7 @@ module Model where
 import qualified ClassyPrelude.Yesod as CP
 import qualified Control.Monad.Combinators as PC (between)
 import qualified Data.Aeson as A
+import qualified Data.Aeson.KeyMap as KM
 import qualified Data.Aeson.Types as A (parseFail)
 import qualified Data.Attoparsec.Text as P
 import qualified Data.Time as TI (ParseTime)
@@ -488,7 +489,7 @@ isExpanded TagCloudModeNone = False
 
 instance FromJSON TagCloudMode where
   parseJSON (Object o) =
-    case lookup "mode" o of
+    case KM.lookup "mode" o of
       Just (String "top") -> TagCloudModeTop <$> o .: "expanded" <*> o .: "value"
       Just (String "lowerBound") -> TagCloudModeLowerBound <$> o .: "expanded" <*> o .: "value"
       Just (String "related") -> TagCloudModeRelated <$> o .: "expanded" <*> fmap words (o .: "value")

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,3 @@
-resolver: lts-18.8
-# allow-newer: true
+resolver: lts-19.4
 packages:
-- '.'
-extra-deps:
-  # - ekg-0.4.0.15
-  # - ekg-json-0.1.0.6
-  # - monad-metrics-0.2.1.4
-  # - wai-middleware-metrics-0.2.4
-- classy-prelude-yesod-1.5.0@sha256:8f7e183bdfd6d2ea9674284c4f285294ab086aff60d9be4e5d7d2f3c1a2b05b7,1330
-- yesod-newsfeed-1.7.0.0
+- .

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,24 +3,10 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: classy-prelude-yesod-1.5.0@sha256:8f7e183bdfd6d2ea9674284c4f285294ab086aff60d9be4e5d7d2f3c1a2b05b7,1330
-    pantry-tree:
-      size: 330
-      sha256: ae84d4cc0e1daf985db6cdcf2ac92319531b8e60f547183cc46480d00aafbe20
-  original:
-    hackage: classy-prelude-yesod-1.5.0@sha256:8f7e183bdfd6d2ea9674284c4f285294ab086aff60d9be4e5d7d2f3c1a2b05b7,1330
-- completed:
-    hackage: yesod-newsfeed-1.7.0.0@sha256:ba49f9af47fe96c521ed889bf041c559b4bddb60a81f385449f7557f8f4aaef2,1345
-    pantry-tree:
-      size: 488
-      sha256: 96027436cc6dc07bca3f691f2d17a5b3993e980f73076c7b1b4d9c5c3ac5cb86
-  original:
-    hackage: yesod-newsfeed-1.7.0.0
+packages: []
 snapshots:
 - completed:
-    size: 587126
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/8.yaml
-    sha256: 93a107557e8691ed5ca17beaee41e68222b142c48868fc8c04a4181fb233477d
-  original: lts-18.8
+    size: 618683
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/4.yaml
+    sha256: d4ee004c46ba878d2f304f5d748d493057be579192a8d148527f3ba55c9df57f
+  original: lts-19.4


### PR DESCRIPTION
With the release of GHC 9.0 LTS snapshot on Stackage, and considering the fact that Nix-Haskell infrastructure moved to GHC 9, I think we can migrate to GHC 9 as well. This PR migrates to the `lts-19.4` snapshot and fixes the corresponding build errors.