### PR TITLE
Fixed login and add button colour on iOS

### DIFF
--- a/purs/src/Component/Add.purs
+++ b/purs/src/Component/Add.purs
@@ -130,14 +130,14 @@ addbmark b' =
              ]
            , tr_
              [ td_ [ ]
-             , td_ [ input [ type_ InputSubmit , class_ "ph3 pv2 input-reset ba b--navy bg-transparent pointer f6 dib mt1 dim"
+             , td_ [ input [ type_ InputSubmit , class_ "ph3 pv2 input-reset black-70 ba b--navy bg-transparent pointer f6 dib mt1 dim"
                            , value (if bm.bid > 0 then "update bookmark" else "add bookmark") ] ]
              ]
            ]
          ]
        ]
 
-     display_exists _ = 
+     display_exists _ =
        div [ class_ "alert" ]
        [ text "previously saved "
        , span [ class_ "link f7 dib gray pr3" , title (maybe bm.time snd mmoment) ]
@@ -148,12 +148,12 @@ addbmark b' =
            , span ([ class_ "confirm red" ] <> guard (not s.deleteAsk) [ attr "hidden" "hidden" ])
              [ button [ type_ ButtonButton, onClick \_ -> BDeleteAsk false] [ text "cancel / " ]
              , button [ type_ ButtonButton, onClick \_ -> BDestroy, class_ "red" ] [ text "destroy" ]
-             ] 
+             ]
            ]
          ]
        ]
 
-     alert_notification alert_text _ = 
+     alert_notification alert_text _ =
        div [ class_ "alert alert-err" ] [ text alert_text ]
 
      display_destroyed _ = p [ class_ "red"] [text "you killed this bookmark"]
@@ -195,7 +195,7 @@ addbmark b' =
 
   handleAction (BEditSubmit e) = do
     liftEffect (preventDefault e)
-    edit_bm <- use _edit_bm 
+    edit_bm <- use _edit_bm
     _apiError .= Nothing
     H.liftAff (editBookmark edit_bm) >>= case _ of
       Left affErr -> do

--- a/templates/login.hamlet
+++ b/templates/login.hamlet
@@ -14,7 +14,7 @@
         <div>
           <label .db.fw6.lh-copy.f6 for="password">Password
           <input #password .w-100.pa1.mb2.ba.b--black-20 name="password" type="password">
-        
-        <input class="ph3 pv2 input-reset ba b--navy bg-transparent pointer f6 dib mt3 dim" type="submit" value="Log In">
+
+        <input class="ph3 pv2 input-reset black-70 ba b--navy bg-transparent pointer f6 dib mt3 dim" type="submit" value="Log In">
 
 <script> document.body.classList.add("bg-near-white");


### PR DESCRIPTION
On iOS the login and add buttons (add bookmark, add note) text was not visible, showing only the outline of the button. This change sets an excplicit colour for the button text `black-70`. The choice among tachyon classes here is arbitrary and could be styled differently according to preference.

This addresses #63 

To incorporate changes:

```bash
cd purs         # navigate to PureScript dir
npm install     # install dependencies including spago
make            # build

stack build     # build main project
```