### PR TITLE
prevent private tags (starts with ".") from showing on public bookmark listing for a user if not owned (fixes #66)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.27 (2026-05-05)
+
+- prevent private tags (starts with ".") from showing on public bookmark listing for a user if not owned
+
 ## v0.0.26 (2026-05-04)
 
 - Add Tag Suggestion when adding/editing bookmarks.

--- a/espial.cabal
+++ b/espial.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           espial
-version:        0.0.26
+version:        0.0.27
 synopsis:       Espial is an open-source, web-based bookmarking server.
 description:     Espial is an open-source, web-based bookmarking server.
                 - Yesod + TypeScript + sqlite3

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 name:    espial
 synopsis: Espial is an open-source, web-based bookmarking server.
-version: "0.0.26"
+version: "0.0.27"
 description: ! '
   Espial is an open-source, web-based bookmarking server.
 

--- a/src/Handler/User.hs
+++ b/src/Handler/User.hs
@@ -47,7 +47,7 @@ _getUser unamep@(UserNameP uname) sharedp' filterp' (TagsP pathtags) = do
     when
       (not isowner && userPrivacyLock user)
       (redirect (AuthR LoginR))
-    (userSuggestTags user,) <$> bookmarksTagsQuery userId sharedp filterp pathtags mquery limit page
+    (userSuggestTags user,) <$> bookmarksTagsQuery userId isowner sharedp filterp pathtags mquery limit page
   when (bcount == 0) (case filterp of FilterSingle _ -> notFound; _ -> pure ())
   mroute <- getCurrentRoute
   tagCloudMode <- getTagCloudMode isowner pathtags
@@ -152,7 +152,7 @@ _getUserFeed unamep@(UserNameP uname) sharedp' filterp' (TagsP pathtags) = do
     when
       (not isowner && userPrivacyLock user)
       (redirect (AuthR LoginR))
-    bookmarksTagsQuery userId sharedp filterp pathtags mquery limit page
+    bookmarksTagsQuery userId isowner sharedp filterp pathtags mquery limit page
   let (descr :: Html) = toHtml $ H.text ("Bookmarks saved by " <> uname)
       entries = map bookmarkToRssEntry btmarks
   updated <- case maximumMay (map feedEntryUpdated entries) of

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -163,6 +163,7 @@ getApiKeyUser apiKey =
 -- returns a list of pair of bookmark with tags merged into a string
 bookmarksTagsQuery ::
   Key User ->
+  Bool ->
   SharedP ->
   FilterP ->
   [Tag] ->
@@ -170,7 +171,7 @@ bookmarksTagsQuery ::
   Limit ->
   Page ->
   DB (Int, [(Entity Bookmark, Maybe Text)])
-bookmarksTagsQuery userId sharedp filterp tags mquery limit' page =
+bookmarksTagsQuery userId isowner sharedp filterp tags mquery limit' page =
   (,) -- total count
     <$> fmap
       (sum . fmap unValue)
@@ -190,6 +191,9 @@ bookmarksTagsQuery userId sharedp filterp tags mquery limit' page =
             ( b,
               subSelect $ from (table @BookmarkTag) >>= \t -> do
                 where_ (t ^. BookmarkTagBookmarkId ==. b ^. BookmarkId)
+                when
+                  (not isowner)
+                  (where_ (not_ (t ^. BookmarkTagTag `like` val ".%")))
                 groupBy (t ^. BookmarkTagBookmarkId)
                 orderBy [asc (t ^. BookmarkTagSeq)]
                 pure $ sqliteGroupConcat (t ^. BookmarkTagTag) (val " ")


### PR DESCRIPTION
prevent private tags (starts with ".") from showing on public bookmark listing for a user if not owned (fixes #66)