### PR TITLE
fix tag suggestion behavior,  add commands: `importnetscapebookmarks`, `exportnetscapebookmarks` (fixes #30), fix command `ImportBookmarks` (fixes #32)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ purs/docset/purescript-local.docset/
 *.sqlite3*
 *bookmarks*.json
 *.log
+*.html

--- a/app/migration/Main.hs
+++ b/app/migration/Main.hs
@@ -50,12 +50,17 @@ data MigrationOpts
         userName :: Text,
         bookmarkFile :: FilePath
       }
+  | ExportBookmarks
+      { conn :: Maybe Text,
+        userName :: Text,
+        bookmarkFile :: FilePath
+      }
   | ImportFirefoxBookmarks
       { conn :: Maybe Text,
         userName :: Text,
         bookmarkFile :: FilePath
       }
-  | ExportBookmarks
+  | ImportNetscapeBookmarks
       { conn :: Maybe Text,
         userName :: Text,
         bookmarkFile :: FilePath
@@ -69,11 +74,6 @@ data MigrationOpts
       { conn :: Maybe Text,
         userName :: Text,
         noteDirectory :: FilePath
-      }
-  | ImportNetscapeBookmarks
-      { conn :: Maybe Text,
-        userName :: Text,
-        bookmarkFile :: FilePath
       }
   | PrintMigrateDB {conn :: Maybe Text}
   deriving (Generic, Show)

--- a/app/migration/Main.hs
+++ b/app/migration/Main.hs
@@ -8,7 +8,9 @@ import qualified Database.Persist as P
 import qualified Database.Persist.Sqlite as P
 import Lens.Micro
 import Model
-import ModelCustom
+import Model.Custom
+import Model.File
+import Model.FileNetscape (exportNetscapeBookmarks)
 import qualified Options.Applicative as OA
 import Options.Applicative.Help (suggestionsHelp)
 import Options.Generic
@@ -58,10 +60,20 @@ data MigrationOpts
         userName :: Text,
         bookmarkFile :: FilePath
       }
+  | ExportNetscapeBookmarks
+      { conn :: Maybe Text,
+        userName :: Text,
+        bookmarkFile :: FilePath
+      }
   | ImportNotes
       { conn :: Maybe Text,
         userName :: Text,
         noteDirectory :: FilePath
+      }
+  | ImportNetscapeBookmarks
+      { conn :: Maybe Text,
+        userName :: Text,
+        bookmarkFile :: FilePath
       }
   | PrintMigrateDB {conn :: Maybe Text}
   deriving (Generic, Show)
@@ -71,20 +83,18 @@ instance ParseRecord MigrationOpts
 main :: IO ()
 main = do
   args <- getRecord "Migrations"
-  connText <-
-    maybe
-      (P.sqlDatabase . appDatabaseConf <$> loadYamlSettings [configSettingsYml] [] useEnv)
-      pure
-      (conn args)
   case args of
-    PrintMigrateDB {..} ->
+    PrintMigrateDB {..} -> do
+      connText <- getConnText conn
       P.runSqlite connText dumpMigration
     CreateDB {..} -> do
+      connText <- getConnText conn
       let connInfo =
             P.mkSqliteConnectionInfo connText
               & set P.fkEnabled False
       P.runSqliteInfo connInfo runMigrations
-    CreateUser {..} ->
+    CreateUser {..} -> do
+      connText <- getConnText conn
       P.runSqlite connText $ do
         passwordText <- liftIO . fmap T.strip $ case userPassword of
           PasswordText s -> pure s
@@ -101,13 +111,15 @@ main = do
               UserPrivacyLock P.=. fromMaybe False privacyLock
             ]
         pure () :: DB ()
-    ShowUser {..} ->
+    ShowUser {..} -> do
+      connText <- getConnText conn
       P.runSqlite connText $ do
         muser <- P.getBy (UniqueUserName userName)
         case muser of
           Nothing -> liftIO (print (userName ++ " not found"))
           Just (P.Entity _ user) -> liftIO (putStrLn (formatUserSummary user))
-    CreateApiKey {..} ->
+    CreateApiKey {..} -> do
+      connText <- getConnText conn
       P.runSqlite connText $ do
         apiKey@(ApiKey plainKey) <- liftIO generateApiKey
         muser <- P.getBy (UniqueUserName userName)
@@ -119,14 +131,16 @@ main = do
             let hashedKey = hashApiKey apiKey
             P.update uid [UserApiToken P.=. Just hashedKey]
             liftIO $ print plainKey
-    DeleteApiKey {..} ->
+    DeleteApiKey {..} -> do
+      connText <- getConnText conn
       P.runSqlite connText $ do
         muser <- P.getBy (UniqueUserName userName)
         case muser of
           Nothing -> liftIO (print (userName ++ " not found"))
           Just (P.Entity uid _) -> do
             P.update uid [UserApiToken P.=. Nothing]
-    DeleteUser {..} ->
+    DeleteUser {..} -> do
+      connText <- getConnText conn
       P.runSqlite connText $ do
         muser <- P.getBy (UniqueUserName userName)
         case muser of
@@ -134,13 +148,15 @@ main = do
           Just (P.Entity uid _) -> do
             P.delete uid
             pure () :: DB ()
-    ExportBookmarks {..} ->
+    ExportBookmarks {..} -> do
+      connText <- getConnText conn
       P.runSqlite connText $ do
         muser <- P.getBy (UniqueUserName userName)
         case muser of
           Just (P.Entity uid _) -> exportFileBookmarks uid bookmarkFile
           Nothing -> liftIO (print (userName ++ "not found"))
-    ImportBookmarks {..} ->
+    ImportBookmarks {..} -> do
+      connText <- getConnText conn
       P.runSqlite connText $ do
         muser <- P.getBy (UniqueUserName userName)
         case muser of
@@ -150,17 +166,19 @@ main = do
               Left e -> liftIO (print e)
               Right n -> liftIO (print (show n ++ " bookmarks imported."))
           Nothing -> liftIO (print (userName ++ "not found"))
-    ImportFirefoxBookmarks {..} ->
+    ImportFirefoxBookmarks {..} -> do
+      connText <- getConnText conn
       P.runSqlite connText $ do
         muser <- P.getBy (UniqueUserName userName)
         case muser of
           Just (P.Entity uid _) -> do
-            result <- insertFFBookmarks uid bookmarkFile
+            result <- insertFirefoxBookmarks uid bookmarkFile
             case result of
               Left e -> liftIO (print e)
               Right n -> liftIO (print (show n ++ " bookmarks imported."))
           Nothing -> liftIO (print (userName ++ "not found"))
-    ImportNotes {..} ->
+    ImportNotes {..} -> do
+      connText <- getConnText conn
       P.runSqlite connText $ do
         muser <- P.getBy (UniqueUserName userName)
         case muser of
@@ -170,7 +188,32 @@ main = do
               Left e -> liftIO (print e)
               Right n -> liftIO (print (show n ++ " notes imported."))
           Nothing -> liftIO (print (userName ++ "not found"))
+    ImportNetscapeBookmarks {..} -> do
+      connText <- getConnText conn
+      P.runSqlite connText $ do
+        muser <- P.getBy (UniqueUserName userName)
+        case muser of
+          Just (P.Entity uid _) -> do
+            result <- insertNetscapeBookmarks uid bookmarkFile
+            case result of
+              Left e -> liftIO (print e)
+              Right n -> liftIO (print (show n ++ " bookmarks imported."))
+          Nothing -> liftIO (print (userName ++ "not found"))
+    ExportNetscapeBookmarks {..} -> do
+      connText <- getConnText conn
+      P.runSqlite connText $ do
+        muser <- P.getBy (UniqueUserName userName)
+        case muser of
+          Just (P.Entity uid _) -> exportNetscapeBookmarks uid bookmarkFile
+          Nothing -> liftIO (print (userName ++ "not found"))
   where
+    getConnText :: Maybe Text -> IO Text
+    getConnText mconn =
+      maybe
+        (P.sqlDatabase . appDatabaseConf <$> loadYamlSettings [configSettingsYml] [] useEnv)
+        pure
+        mconn
+
     formatUserSummary :: User -> Text
     formatUserSummary User {..} =
       intercalate

--- a/changelog.md
+++ b/changelog.md
@@ -2,8 +2,9 @@
 
 ## v0.0.29
 
+- Extend migration to add commands: `importnetscapebookmarks`, `exportnetscapebookmarks` (fixes #30)
+- fix migration command `ImportBookmarks` (pinboard import file) parsing bug to handle when the description is a boolean (fixes #32)
 - tag suggestions: when a tag exactly matches an existing tag, it will appear first in the suggestion list
-- fix pinboard import file parsing bug to handle when the description is a boolean (fixes #32)
 
 ## v0.0.28 (2026-05-06)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.0.29
+## v0.0.29 (2026-05-07)
 
 - Extend migration to add commands: `importnetscapebookmarks`, `exportnetscapebookmarks` (fixes #30)
 - fix migration command `ImportBookmarks` (pinboard import file) parsing bug to handle when the description is a boolean (fixes #32)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.29
+
+- tag suggestions: when a tag exactly matches an existing tag, it will appear first in the suggestion list
+
 ## v0.0.28 (2026-05-06)
 
 - add new app setting: `archive-backend: "_env:ARCHIVE_BACKEND:disabled"`

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## v0.0.29
 
 - tag suggestions: when a tag exactly matches an existing tag, it will appear first in the suggestion list
+- fix pinboard import file parsing bug to handle when the description is a boolean (fixes #32)
 
 ## v0.0.28 (2026-05-06)
 

--- a/espial.cabal
+++ b/espial.cabal
@@ -119,7 +119,13 @@ library
       Import
       Import.NoFoundation
       Model
-      ModelCustom
+      Model.Custom
+      Model.File
+      Model.FileBookmark
+      Model.FileFirefox
+      Model.FileNetscape
+      Model.FileNote
+      Model.Form
       PathPiece
       Pretty
       Settings

--- a/espial.cabal
+++ b/espial.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           espial
-version:        0.0.28
+version:        0.0.29
 synopsis:       Espial is an open-source, web-based bookmarking server.
 description:     Espial is an open-source, web-based bookmarking server.
                 - Yesod + TypeScript + sqlite3

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 name:    espial
 synopsis: Espial is an open-source, web-based bookmarking server.
-version: "0.0.28"
+version: "0.0.29"
 description: ! '
   Espial is an open-source, web-based bookmarking server.
 

--- a/src/Handler/Notes.hs
+++ b/src/Handler/Notes.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TupleSections #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
 
 module Handler.Notes where

--- a/src/Handler/User.hs
+++ b/src/Handler/User.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TupleSections #-}
 {-# OPTIONS_GHC -fno-warn-unused-matches #-}
 
 module Handler.User where

--- a/src/Import/NoFoundation.hs
+++ b/src/Import/NoFoundation.hs
@@ -19,7 +19,8 @@ import Yesod.Default.Config2 as Import
 import Text.Julius           as Import
 
 import Model as Import
-import ModelCustom as Import
+import Model.Form as Import
+import Model.Custom as Import
 import Types as Import
 import Pretty as Import
 import Data.Functor as Import hiding (unzip)

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -959,7 +959,7 @@ getTagSuggestions user TagSuggestionRequest {_query = query, _currentTags = curr
   values <-
     fmap (bimap unValue unValue)
       <$> ( select $ do
-              (tag, countRows', matchPriority) <- from $ unionAll_ prefixQuery containsOnlyQuery
+              (tag, countRows', matchPriority) <- from suggestionsQuery
               orderBy [asc matchPriority, desc countRows', asc $ lower_ tag]
               limit (fromIntegral top)
               pure (tag, countRows')
@@ -971,22 +971,19 @@ getTagSuggestions user TagSuggestionRequest {_query = query, _currentTags = curr
   where
     excludedTags = take 400 $ map toLower (fromMaybe ([] :: [Text]) currentTags)
 
-    prefixQuery = do
-      t <- from (table @BookmarkTag)
-      where_ (t ^. BookmarkTagUserId ==. val user &&. (lower_ (t ^. BookmarkTagTag) `like` lower_ (val query ++. (%))))
-      unless (null excludedTags) $ where_ $ not_ (lower_ (t ^. BookmarkTagTag) `in_` valList excludedTags)
-      let countRows' = countRows
-      groupBy (lower_ $ t ^. BookmarkTagTag)
-      pure (t ^. BookmarkTagTag, countRows', val (0 :: Int))
-
-    containsOnlyQuery = do
+    suggestionsQuery = do
       t <- from (table @BookmarkTag)
       where_
         ( t ^. BookmarkTagUserId ==. val user
             &&. (lower_ (t ^. BookmarkTagTag) `like` lower_ ((%) ++. val query ++. (%)))
-            &&. not_ (lower_ (t ^. BookmarkTagTag) `like` lower_ (val query ++. (%)))
         )
       unless (null excludedTags) $ where_ $ not_ (lower_ (t ^. BookmarkTagTag) `in_` valList excludedTags)
       let countRows' = countRows
-      groupBy (lower_ $ t ^. BookmarkTagTag)
-      pure (t ^. BookmarkTagTag, countRows', val (1 :: Int))
+          matchPriority =
+            case_
+              [ when_ (lower_ (t ^. BookmarkTagTag) ==. lower_ (val query)) then_ (val (0 :: Int)),
+                when_ (lower_ (t ^. BookmarkTagTag) `like` lower_ (val query ++. (%))) then_ (val (1 :: Int))
+              ]
+              (else_ (val (2 :: Int)))
+      groupBy (lower_ (t ^. BookmarkTagTag))
+      pure (t ^. BookmarkTagTag, countRows', matchPriority)

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveFunctor #-}
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
 module Model where
 
@@ -9,22 +8,18 @@ import qualified Control.Monad.Combinators as PC (between)
 import Control.Monad.Fail (MonadFail)
 import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
 import Control.Monad.Writer (tell)
-import qualified Data.Aeson as A
 import qualified Data.Aeson.KeyMap as KM
 import qualified Data.Aeson.Types as A (parseFail)
 import qualified Data.Attoparsec.Text as P
 import Data.Char (isSpace)
 import Data.Either (fromRight)
 import Data.Foldable (foldl, foldl1, sequenceA_)
-import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Time as TI (ParseTime)
-import qualified Data.Time.Clock.POSIX as TI (POSIXTime, posixSecondsToUTCTime)
-import qualified Data.Time.ISO8601 as TI (formatISO8601Millis, parseISO8601)
+import qualified Data.Time.ISO8601 as TISO (formatISO8601Millis, parseISO8601)
 import Database.Esqueleto.Experimental hiding ((<&>))
 import Database.Esqueleto.Internal.Internal (unsafeSqlFunction)
-import ModelCustom
+import Model.Custom
 import Pretty ()
-import System.Directory (listDirectory)
 import Types
 
 share
@@ -83,8 +78,8 @@ newtype UTCTimeStr
   deriving (Eq, Show, Read, Generic, FromJSON, ToJSON)
 
 instance PathPiece UTCTimeStr where
-  toPathPiece (UTCTimeStr u) = pack (TI.formatISO8601Millis u)
-  fromPathPiece s = UTCTimeStr <$> TI.parseISO8601 (unpack s)
+  toPathPiece (UTCTimeStr u) = pack (TISO.formatISO8601Millis u)
+  fromPathPiece s = UTCTimeStr <$> TISO.parseISO8601 (unpack s)
 
 newtype UserNameP
   = UserNameP {unUserNameP :: Text}
@@ -376,150 +371,11 @@ getNoteList key mquery sharedp limit' page =
             p_after = "after:" *> fmap ((b ^. NoteCreated >=.) . val) (parseTimeText =<< P.takeText)
             p_before = "before:" *> fmap ((b ^. NoteCreated <=.) . val) (parseTimeText =<< P.takeText)
 
--- Bookmark Files
-
 mkBookmarkTags :: Key User -> Key Bookmark -> [Tag] -> [BookmarkTag]
 mkBookmarkTags userId bookmarkId tags =
   (\(i, tag) -> BookmarkTag userId tag bookmarkId i) <$> zip [1 ..] tags
 
-fileBookmarkToBookmark :: UserId -> FileBookmark -> IO Bookmark
-fileBookmarkToBookmark user FileBookmark {..} = do
-  slug <- mkBmSlug
-  pure
-    $ Bookmark
-      { bookmarkUserId = user,
-        bookmarkSlug = slug,
-        bookmarkHref = fileBookmarkHref,
-        bookmarkDescription = fileBookmarkDescription,
-        bookmarkExtended = fileBookmarkExtended,
-        bookmarkTime = fileBookmarkTime,
-        bookmarkShared = fileBookmarkShared,
-        bookmarkToRead = fileBookmarkToRead,
-        bookmarkSelected = Just True == fileBookmarkSelected,
-        bookmarkArchiveHref = fileBookmarkArchiveHref
-      }
-
-bookmarkTofileBookmark :: Bookmark -> Text -> FileBookmark
-bookmarkTofileBookmark Bookmark {..} tags =
-  FileBookmark
-    { fileBookmarkHref = bookmarkHref,
-      fileBookmarkDescription = bookmarkDescription,
-      fileBookmarkExtended = bookmarkExtended,
-      fileBookmarkTime = bookmarkTime,
-      fileBookmarkShared = bookmarkShared,
-      fileBookmarkToRead = bookmarkToRead,
-      fileBookmarkSelected = Just bookmarkSelected,
-      fileBookmarkArchiveHref = bookmarkArchiveHref,
-      fileBookmarkTags = tags
-    }
-
-data FFBookmarkNode = FFBookmarkNode
-  { firefoxBookmarkChildren :: Maybe [FFBookmarkNode],
-    firefoxBookmarkDateAdded :: !TI.POSIXTime,
-    firefoxBookmarkGuid :: !Text,
-    firefoxBookmarkIconUri :: !(Maybe Text),
-    firefoxBookmarkId :: !Int,
-    firefoxBookmarkIndex :: !Int,
-    firefoxBookmarkLastModified :: !TI.POSIXTime,
-    firefoxBookmarkRoot :: !(Maybe Text),
-    firefoxBookmarkTitle :: !Text,
-    firefoxBookmarkType :: !Text,
-    firefoxBookmarkTypeCode :: !Int,
-    firefoxBookmarkUri :: !(Maybe Text)
-  }
-  deriving (Show, Eq, Typeable, Ord)
-
-instance FromJSON FFBookmarkNode where
-  parseJSON (Object o) =
-    FFBookmarkNode
-      <$> (o A..:? "children")
-      <*> (o .: "dateAdded")
-      <*> o
-      .: "guid"
-      <*> (o A..:? "iconUri")
-      <*> o
-      .: "id"
-      <*> o
-      .: "index"
-      <*> (o .: "lastModified")
-      <*> (o A..:? "root")
-      <*> (o .: "title")
-      <*> (o .: "type")
-      <*> (o .: "typeCode")
-      <*> (o A..:? "uri")
-  parseJSON _ = A.parseFail "bad parse"
-
-firefoxBookmarkNodeToBookmark :: UserId -> FFBookmarkNode -> IO [Bookmark]
-firefoxBookmarkNodeToBookmark user FFBookmarkNode {..} =
-  case firefoxBookmarkTypeCode of
-    1 -> do
-      slug <- mkBmSlug
-      pure
-        $ [ Bookmark
-              { bookmarkUserId = user,
-                bookmarkSlug = slug,
-                bookmarkHref = fromMaybe "" firefoxBookmarkUri,
-                bookmarkDescription = firefoxBookmarkTitle,
-                bookmarkExtended = "",
-                bookmarkTime = TI.posixSecondsToUTCTime (firefoxBookmarkDateAdded / 1000000),
-                bookmarkShared = True,
-                bookmarkToRead = False,
-                bookmarkSelected = False,
-                bookmarkArchiveHref = Nothing
-              }
-          ]
-    2 ->
-      join
-        <$> mapM
-          (firefoxBookmarkNodeToBookmark user)
-          (fromMaybe [] firefoxBookmarkChildren)
-    _ -> pure []
-
-insertFileBookmarks :: Key User -> FilePath -> DB (Either String Int)
-insertFileBookmarks userId bookmarkFile = do
-  mfmarks <- liftIO $ readFileBookmarks bookmarkFile
-  case mfmarks of
-    Left e -> pure $ Left e
-    Right fmarks -> do
-      bmarks <- liftIO $ mapM (fileBookmarkToBookmark userId) fmarks
-      mbids <- mapM insertUnique bmarks
-      mapM_ (void . insertUnique)
-        $ concatMap (uncurry (mkBookmarkTags userId))
-        $ catMaybes
-        $ zipWith
-          (\mbid tags -> (,tags) <$> mbid)
-          mbids
-          (extractTags <$> fmarks)
-      pure $ Right (length bmarks)
-  where
-    extractTags = words . fileBookmarkTags
-
-insertFFBookmarks :: Key User -> FilePath -> DB (Either String Int)
-insertFFBookmarks userId bookmarkFile = do
-  mfmarks <- liftIO $ readFFBookmarks bookmarkFile
-  case mfmarks of
-    Left e -> pure $ Left e
-    Right fmarks -> do
-      bmarks <- liftIO $ firefoxBookmarkNodeToBookmark userId fmarks
-      mapM_ (void . insertUnique) bmarks
-      pure $ Right (length bmarks)
-
-readFileBookmarks :: (MonadIO m) => FilePath -> m (Either String [FileBookmark])
-readFileBookmarks fpath =
-  A.eitherDecode' . fromStrict <$> readFile fpath
-
-readFFBookmarks :: (MonadIO m) => FilePath -> m (Either String FFBookmarkNode)
-readFFBookmarks fpath =
-  A.eitherDecode' . fromStrict <$> readFile fpath
-
-exportFileBookmarks :: Key User -> FilePath -> DB ()
-exportFileBookmarks user fpath =
-  liftIO . A.encodeFile fpath =<< getFileBookmarks user
-
-getFileBookmarks :: Key User -> DB [FileBookmark]
-getFileBookmarks user = do
-  marks <- allUserBookmarks user
-  pure $ fmap (\(bm, t) -> bookmarkTofileBookmark (entityVal bm) t) marks
+-- * Bookmark Tag Cloud
 
 data TagCloudMode
   = TagCloudModeTop Bool Int -- { mode: "top", value: 200 }
@@ -625,139 +481,6 @@ tagCountRelated user tags =
             pure (t ^. BookmarkTagTag, countRows')
         )
 
--- Notes
-
-fileNoteToNote :: UserId -> FileNote -> IO Note
-fileNoteToNote user FileNote {..} = do
-  slug <- mkNtSlug
-  pure
-    $ Note
-      { noteUserId = user,
-        noteSlug = slug,
-        noteLength = fileNoteLength,
-        noteTitle = fileNoteTitle,
-        noteText = fileNoteText,
-        noteIsMarkdown = False,
-        noteShared = False,
-        noteCreated = fileNoteCreatedAt,
-        noteUpdated = fileNoteUpdatedAt
-      }
-
-insertDirFileNotes :: Key User -> FilePath -> DB (Either String Int)
-insertDirFileNotes userId noteDirectory = do
-  mfnotes <- liftIO $ readFileNotes noteDirectory
-  case mfnotes of
-    Left e -> pure $ Left e
-    Right fnotes -> do
-      notes <- liftIO $ mapM (fileNoteToNote userId) fnotes
-      void $ mapM insertUnique notes
-      pure $ Right (length notes)
-  where
-    readFileNotes :: (MonadIO m) => FilePath -> m (Either String [FileNote])
-    readFileNotes fdir = do
-      files <- liftIO (listDirectory fdir)
-      noteBSS <- mapM (readFile . (fdir </>)) files
-      pure (mapM (A.eitherDecode' . fromStrict) noteBSS)
-
--- AccountSettingsForm
-data AccountSettingsForm = AccountSettingsForm
-  { _privateDefault :: Bool,
-    _archiveDefault :: Bool,
-    _suggestTags :: Bool,
-    _privacyLock :: Bool,
-    _archiveBackendEnabled :: Bool
-  }
-  deriving (Show, Eq, Read, Generic)
-
-instance FromJSON AccountSettingsForm where parseJSON = A.genericParseJSON gDefaultFormOptions
-
-instance ToJSON AccountSettingsForm where toJSON = A.genericToJSON gDefaultFormOptions
-
-toAccountSettingsForm :: Bool -> User -> AccountSettingsForm
-toAccountSettingsForm archiveBackendEnabled User {..} =
-  AccountSettingsForm
-    { _privateDefault = userPrivateDefault,
-      _archiveDefault = userArchiveDefault,
-      _suggestTags = userSuggestTags,
-      _privacyLock = userPrivacyLock,
-      _archiveBackendEnabled = archiveBackendEnabled
-    }
-
-updateUserFromAccountSettingsForm :: Key User -> AccountSettingsForm -> DB ()
-updateUserFromAccountSettingsForm userId AccountSettingsForm {..} =
-  CP.update
-    userId
-    [ UserPrivateDefault CP.=. _privateDefault,
-      UserArchiveDefault CP.=. _archiveDefault,
-      UserSuggestTags CP.=. _suggestTags,
-      UserPrivacyLock CP.=. _privacyLock
-    ]
-
--- BookmarkForm
-
-data BookmarkForm = BookmarkForm
-  { _url :: Text,
-    _title :: Maybe Text,
-    _description :: Maybe Textarea,
-    _tags :: Maybe Text,
-    _private :: Maybe Bool,
-    _toread :: Maybe Bool,
-    _bid :: Maybe Int64,
-    _slug :: Maybe BmSlug,
-    _selected :: Maybe Bool,
-    _time :: Maybe UTCTimeStr,
-    _archiveUrl :: Maybe Text
-  }
-  deriving (Show, Eq, Read, Generic)
-
-instance FromJSON BookmarkForm where parseJSON = A.genericParseJSON gDefaultFormOptions
-
-instance ToJSON BookmarkForm where toJSON = A.genericToJSON gDefaultFormOptions
-
-gDefaultFormOptions :: A.Options
-gDefaultFormOptions = A.defaultOptions {A.fieldLabelModifier = drop 1}
-
-toBookmarkFormList :: [(Entity Bookmark, Maybe Text)] -> [BookmarkForm]
-toBookmarkFormList = fmap _toBookmarkForm'
-
-_toBookmarkForm :: (Entity Bookmark, [Entity BookmarkTag]) -> BookmarkForm
-_toBookmarkForm (bm, tags) =
-  _toBookmarkForm' (bm, Just $ unwords $ fmap (bookmarkTagTag . entityVal) tags)
-
-_toBookmarkForm' :: (Entity Bookmark, Maybe Text) -> BookmarkForm
-_toBookmarkForm' (Entity bid Bookmark {..}, tags) =
-  BookmarkForm
-    { _url = bookmarkHref,
-      _title = Just bookmarkDescription,
-      _description = Just $ Textarea $ bookmarkExtended,
-      _tags = Just $ fromMaybe "" tags,
-      _private = Just $ not bookmarkShared,
-      _toread = Just bookmarkToRead,
-      _bid = Just $ fromSqlKey $ bid,
-      _slug = Just bookmarkSlug,
-      _selected = Just bookmarkSelected,
-      _time = Just $ UTCTimeStr $ bookmarkTime,
-      _archiveUrl = bookmarkArchiveHref
-    }
-
-_toBookmark :: UserId -> BookmarkForm -> IO Bookmark
-_toBookmark userId BookmarkForm {..} = do
-  time <- liftIO getCurrentTime
-  slug <- maybe mkBmSlug pure _slug
-  pure
-    $ Bookmark
-      { bookmarkUserId = userId,
-        bookmarkSlug = slug,
-        bookmarkHref = _url,
-        bookmarkDescription = fromMaybe "" _title,
-        bookmarkExtended = maybe "" unTextarea _description,
-        bookmarkTime = maybe time unUTCTimeStr _time,
-        bookmarkShared = maybe True not _private,
-        bookmarkToRead = Just True == _toread,
-        bookmarkSelected = Just True == _selected,
-        bookmarkArchiveHref = _archiveUrl
-      }
-
 fetchBookmarkByUrl :: Key User -> Maybe Text -> DB (Maybe (Entity Bookmark, [Entity BookmarkTag]))
 fetchBookmarkByUrl userId murl = runMaybeT do
   bmark <- MaybeT . getBy . UniqueUserHref userId =<< MaybeT (pure murl)
@@ -823,170 +546,3 @@ upsertNote userId mnid note =
         _ -> throwString "not found"
     Nothing -> do
       Created <$> insert note
-
--- * FileBookmarks
-
-data FileBookmark = FileBookmark
-  { fileBookmarkHref :: !Text,
-    fileBookmarkDescription :: !Text,
-    fileBookmarkExtended :: !Text,
-    fileBookmarkTime :: !UTCTime,
-    fileBookmarkShared :: !Bool,
-    fileBookmarkToRead :: !Bool,
-    fileBookmarkSelected :: !(Maybe Bool),
-    fileBookmarkArchiveHref :: !(Maybe Text),
-    fileBookmarkTags :: !Text
-  }
-  deriving (Show, Eq, Typeable, Ord)
-
-instance FromJSON FileBookmark where
-  parseJSON (Object o) =
-    FileBookmark
-      <$> o
-      .: "href"
-      <*> (parseDescriptionValue =<< o .: "description")
-      <*> o
-      .: "extended"
-      <*> o
-      .: "time"
-      <*> (boolFromYesNo <$> o .: "shared")
-      <*> (boolFromYesNo <$> o .: "toread")
-      <*> (o A..:? "selected")
-      <*> (o A..:? "archive_url")
-      <*> (o .: "tags")
-    where
-      parseDescriptionValue (String t) = pure t
-      parseDescriptionValue (Bool _) = pure ""
-      parseDescriptionValue _ = A.parseFail "bad parse"
-  parseJSON _ = A.parseFail "bad parse"
-
-instance ToJSON FileBookmark where
-  toJSON FileBookmark {..} =
-    object
-      [ "href" .= toJSON fileBookmarkHref,
-        "description" .= toJSON fileBookmarkDescription,
-        "extended" .= toJSON fileBookmarkExtended,
-        "time" .= toJSON fileBookmarkTime,
-        "shared" .= toJSON (boolToYesNo fileBookmarkShared),
-        "toread" .= toJSON (boolToYesNo fileBookmarkToRead),
-        "selected" .= toJSON fileBookmarkSelected,
-        "archive_url" .= toJSON fileBookmarkArchiveHref,
-        "tags" .= toJSON fileBookmarkTags
-      ]
-
-boolFromYesNo :: Text -> Bool
-boolFromYesNo "yes" = True
-boolFromYesNo _ = False
-
-boolToYesNo :: Bool -> Text
-boolToYesNo True = "yes"
-boolToYesNo _ = "no"
-
--- * FileNotes
-
-data FileNote = FileNote
-  { fileNoteId :: !Text,
-    fileNoteTitle :: !Text,
-    fileNoteText :: !Text,
-    fileNoteLength :: !Int,
-    fileNoteCreatedAt :: !UTCTime,
-    fileNoteUpdatedAt :: !UTCTime
-  }
-  deriving (Show, Eq, Typeable, Ord)
-
-instance FromJSON FileNote where
-  parseJSON (Object o) =
-    FileNote
-      <$> o
-      .: "id"
-      <*> o
-      .: "title"
-      <*> o
-      .: "text"
-      <*> o
-      .: "length"
-      <*> (readFileNoteTime =<< o .: "created_at")
-      <*> (readFileNoteTime =<< o .: "updated_at")
-  parseJSON _ = A.parseFail "bad parse"
-
-instance ToJSON FileNote where
-  toJSON FileNote {..} =
-    object
-      [ "id" .= toJSON fileNoteId,
-        "title" .= toJSON fileNoteTitle,
-        "text" .= toJSON fileNoteText,
-        "length" .= toJSON fileNoteLength,
-        "created_at" .= toJSON (showFileNoteTime fileNoteCreatedAt),
-        "updated_at" .= toJSON (showFileNoteTime fileNoteUpdatedAt)
-      ]
-
-readFileNoteTime ::
-  (MonadFail m) =>
-  String -> m UTCTime
-readFileNoteTime = parseTimeM True defaultTimeLocale "%F %T"
-
-showFileNoteTime :: UTCTime -> String
-showFileNoteTime = formatTime defaultTimeLocale "%F %T"
-
-data TagSuggestionRequest = TagSuggestionRequest
-  { _query :: Text,
-    _currentTags :: Maybe [Text]
-  }
-  deriving (Show, Eq, Read, Generic)
-
-data TagSuggestionResponse = TagSuggestionResponse
-  { _suggestions :: [Suggestion]
-  }
-  deriving (Show, Eq, Read, Generic)
-
-data Suggestion = Suggestion
-  { _term :: Text,
-    _count :: Int
-  }
-  deriving (Show, Eq, Read, Generic)
-
-instance FromJSON TagSuggestionRequest where parseJSON = A.genericParseJSON gDefaultFormOptions
-
-instance ToJSON TagSuggestionRequest where toJSON = A.genericToJSON gDefaultFormOptions
-
-instance FromJSON TagSuggestionResponse where parseJSON = A.genericParseJSON gDefaultFormOptions
-
-instance ToJSON TagSuggestionResponse where toJSON = A.genericToJSON gDefaultFormOptions
-
-instance FromJSON Suggestion where parseJSON = A.genericParseJSON gDefaultFormOptions
-
-instance ToJSON Suggestion where toJSON = A.genericToJSON gDefaultFormOptions
-
-getTagSuggestions :: Key User -> TagSuggestionRequest -> Int -> DB TagSuggestionResponse
-getTagSuggestions user TagSuggestionRequest {_query = query, _currentTags = currentTags} top = do
-  values <-
-    fmap (bimap unValue unValue)
-      <$> ( select $ do
-              (tag, countRows', matchPriority) <- from suggestionsQuery
-              orderBy [asc matchPriority, desc countRows', asc $ lower_ tag]
-              limit (fromIntegral top)
-              pure (tag, countRows')
-          )
-  pure
-    TagSuggestionResponse
-      { _suggestions = uncurry Suggestion <$> values
-      }
-  where
-    excludedTags = take 400 $ map toLower (fromMaybe ([] :: [Text]) currentTags)
-
-    suggestionsQuery = do
-      t <- from (table @BookmarkTag)
-      where_
-        ( t ^. BookmarkTagUserId ==. val user
-            &&. (lower_ (t ^. BookmarkTagTag) `like` lower_ ((%) ++. val query ++. (%)))
-        )
-      unless (null excludedTags) $ where_ $ not_ (lower_ (t ^. BookmarkTagTag) `in_` valList excludedTags)
-      let countRows' = countRows
-          matchPriority =
-            case_
-              [ when_ (lower_ (t ^. BookmarkTagTag) ==. lower_ (val query)) then_ (val (0 :: Int)),
-                when_ (lower_ (t ^. BookmarkTagTag) `like` lower_ (val query ++. (%))) then_ (val (1 :: Int))
-              ]
-              (else_ (val (2 :: Int)))
-      groupBy (lower_ (t ^. BookmarkTagTag))
-      pure (t ^. BookmarkTagTag, countRows', matchPriority)

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -844,8 +844,7 @@ instance FromJSON FileBookmark where
     FileBookmark
       <$> o
       .: "href"
-      <*> o
-      .: "description"
+      <*> (parseDescriptionValue =<< o .: "description")
       <*> o
       .: "extended"
       <*> o
@@ -855,6 +854,10 @@ instance FromJSON FileBookmark where
       <*> (o A..:? "selected")
       <*> (o A..:? "archive_url")
       <*> (o .: "tags")
+    where
+      parseDescriptionValue (String t) = pure t
+      parseDescriptionValue (Bool _) = pure ""
+      parseDescriptionValue _ = A.parseFail "bad parse"
   parseJSON _ = A.parseFail "bad parse"
 
 instance ToJSON FileBookmark where

--- a/src/Model/Custom.hs
+++ b/src/Model/Custom.hs
@@ -1,5 +1,5 @@
 
-module ModelCustom where
+module Model.Custom where
 
 import Prelude
 

--- a/src/Model/File.hs
+++ b/src/Model/File.hs
@@ -1,0 +1,12 @@
+module Model.File
+  ( module Model.FileBookmark,
+    module Model.FileFirefox,
+    module Model.FileNetscape,
+    module Model.FileNote,
+  )
+where
+
+import Model.FileBookmark
+import Model.FileFirefox
+import Model.FileNetscape
+import Model.FileNote

--- a/src/Model/FileBookmark.hs
+++ b/src/Model/FileBookmark.hs
@@ -1,0 +1,131 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Model.FileBookmark where
+
+import ClassyPrelude.Yesod hiding (Value, exists, groupBy, on, (<=.), (==.), (>=.), (||.))
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Types as A (parseFail)
+import Model
+import Model.Custom
+import Types
+
+-- * FileBookmarks
+
+data FileBookmark = FileBookmark
+  { fileBookmarkHref :: !Text,
+    fileBookmarkDescription :: !Text,
+    fileBookmarkExtended :: !Text,
+    fileBookmarkTime :: !UTCTime,
+    fileBookmarkShared :: !Bool,
+    fileBookmarkToRead :: !Bool,
+    fileBookmarkSelected :: !(Maybe Bool),
+    fileBookmarkArchiveHref :: !(Maybe Text),
+    fileBookmarkTags :: !Text
+  }
+  deriving (Show, Eq, Typeable, Ord)
+
+instance FromJSON FileBookmark where
+  parseJSON (Object o) =
+    FileBookmark
+      <$> o
+      .: "href"
+      <*> (parseDescriptionValue =<< o .: "description")
+      <*> o
+      .: "extended"
+      <*> o
+      .: "time"
+      <*> (boolFromYesNo <$> o .: "shared")
+      <*> (boolFromYesNo <$> o .: "toread")
+      <*> (o A..:? "selected")
+      <*> (o A..:? "archive_url")
+      <*> (o .: "tags")
+    where
+      parseDescriptionValue (String t) = pure t
+      parseDescriptionValue (Bool _) = pure ""
+      parseDescriptionValue _ = A.parseFail "bad parse"
+  parseJSON _ = A.parseFail "bad parse"
+
+instance ToJSON FileBookmark where
+  toJSON FileBookmark {..} =
+    object
+      [ "href" .= toJSON fileBookmarkHref,
+        "description" .= toJSON fileBookmarkDescription,
+        "extended" .= toJSON fileBookmarkExtended,
+        "time" .= toJSON fileBookmarkTime,
+        "shared" .= toJSON (boolToYesNo fileBookmarkShared),
+        "toread" .= toJSON (boolToYesNo fileBookmarkToRead),
+        "selected" .= toJSON fileBookmarkSelected,
+        "archive_url" .= toJSON fileBookmarkArchiveHref,
+        "tags" .= toJSON fileBookmarkTags
+      ]
+
+boolFromYesNo :: Text -> Bool
+boolFromYesNo "yes" = True
+boolFromYesNo _ = False
+
+boolToYesNo :: Bool -> Text
+boolToYesNo True = "yes"
+boolToYesNo _ = "no"
+
+fileBookmarkToBookmark :: UserId -> FileBookmark -> IO Bookmark
+fileBookmarkToBookmark user FileBookmark {..} = do
+  slug <- mkBmSlug
+  pure
+    $ Bookmark
+      { bookmarkUserId = user,
+        bookmarkSlug = slug,
+        bookmarkHref = fileBookmarkHref,
+        bookmarkDescription = fileBookmarkDescription,
+        bookmarkExtended = fileBookmarkExtended,
+        bookmarkTime = fileBookmarkTime,
+        bookmarkShared = fileBookmarkShared,
+        bookmarkToRead = fileBookmarkToRead,
+        bookmarkSelected = Just True == fileBookmarkSelected,
+        bookmarkArchiveHref = fileBookmarkArchiveHref
+      }
+
+bookmarkTofileBookmark :: Bookmark -> Text -> FileBookmark
+bookmarkTofileBookmark Bookmark {..} tags =
+  FileBookmark
+    { fileBookmarkHref = bookmarkHref,
+      fileBookmarkDescription = bookmarkDescription,
+      fileBookmarkExtended = bookmarkExtended,
+      fileBookmarkTime = bookmarkTime,
+      fileBookmarkShared = bookmarkShared,
+      fileBookmarkToRead = bookmarkToRead,
+      fileBookmarkSelected = Just bookmarkSelected,
+      fileBookmarkArchiveHref = bookmarkArchiveHref,
+      fileBookmarkTags = tags
+    }
+
+readFileBookmarks :: (MonadIO m) => FilePath -> m (Either String [FileBookmark])
+readFileBookmarks fpath =
+  A.eitherDecode' . fromStrict <$> readFile fpath
+
+insertFileBookmarks :: Key User -> FilePath -> DB (Either String Int)
+insertFileBookmarks userId bookmarkFile = do
+  mfmarks <- liftIO $ readFileBookmarks bookmarkFile
+  case mfmarks of
+    Left e -> pure $ Left e
+    Right fmarks -> do
+      bmarks <- liftIO $ mapM (fileBookmarkToBookmark userId) fmarks
+      mbids <- mapM insertUnique bmarks
+      mapM_ (void . insertUnique)
+        $ concatMap (uncurry (mkBookmarkTags userId))
+        $ catMaybes
+        $ zipWith
+          (\mbid tags -> (,tags) <$> mbid)
+          mbids
+          (extractTags <$> fmarks)
+      pure $ Right (length bmarks)
+  where
+    extractTags = words . fileBookmarkTags
+
+exportFileBookmarks :: Key User -> FilePath -> DB ()
+exportFileBookmarks user fpath =
+  liftIO . A.encodeFile fpath =<< getFileBookmarks
+  where
+    getFileBookmarks :: DB [FileBookmark]
+    getFileBookmarks = do
+      marks <- allUserBookmarks user
+      pure $ fmap (\(bm, t) -> bookmarkTofileBookmark (entityVal bm) t) marks

--- a/src/Model/FileFirefox.hs
+++ b/src/Model/FileFirefox.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Model.FileFirefox where
+
+import ClassyPrelude.Yesod hiding (Value, exists, groupBy, on, (<=.), (==.), (>=.), (||.))
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Types as A (parseFail)
+import qualified Data.Time.Clock.POSIX as TI (POSIXTime, posixSecondsToUTCTime)
+import Model
+import Model.Custom
+import Types
+
+-- * Firefox Bookmarks
+
+data FirefoxBookmarkNode = FirefoxBookmarkNode
+  { firefoxBookmarkChildren :: Maybe [FirefoxBookmarkNode],
+    firefoxBookmarkDateAdded :: !TI.POSIXTime,
+    firefoxBookmarkGuid :: !Text,
+    firefoxBookmarkIconUri :: !(Maybe Text),
+    firefoxBookmarkId :: !Int,
+    firefoxBookmarkIndex :: !Int,
+    firefoxBookmarkLastModified :: !TI.POSIXTime,
+    firefoxBookmarkRoot :: !(Maybe Text),
+    firefoxBookmarkTitle :: !Text,
+    firefoxBookmarkType :: !Text,
+    firefoxBookmarkTypeCode :: !Int,
+    firefoxBookmarkUri :: !(Maybe Text)
+  }
+  deriving (Show, Eq, Typeable, Ord)
+
+instance FromJSON FirefoxBookmarkNode where
+  parseJSON (Object o) =
+    FirefoxBookmarkNode
+      <$> (o A..:? "children")
+      <*> (o .: "dateAdded")
+      <*> o
+      .: "guid"
+      <*> (o A..:? "iconUri")
+      <*> o
+      .: "id"
+      <*> o
+      .: "index"
+      <*> (o .: "lastModified")
+      <*> (o A..:? "root")
+      <*> (o .: "title")
+      <*> (o .: "type")
+      <*> (o .: "typeCode")
+      <*> (o A..:? "uri")
+  parseJSON _ = A.parseFail "bad parse"
+
+firefoxBookmarkNodeToBookmark :: UserId -> FirefoxBookmarkNode -> IO [Bookmark]
+firefoxBookmarkNodeToBookmark user FirefoxBookmarkNode {..} =
+  case firefoxBookmarkTypeCode of
+    1 -> do
+      slug <- mkBmSlug
+      pure
+        $ [ Bookmark
+              { bookmarkUserId = user,
+                bookmarkSlug = slug,
+                bookmarkHref = fromMaybe "" firefoxBookmarkUri,
+                bookmarkDescription = firefoxBookmarkTitle,
+                bookmarkExtended = "",
+                bookmarkTime = TI.posixSecondsToUTCTime (firefoxBookmarkDateAdded / 1000000),
+                bookmarkShared = True,
+                bookmarkToRead = False,
+                bookmarkSelected = False,
+                bookmarkArchiveHref = Nothing
+              }
+          ]
+    2 ->
+      join
+        <$> mapM
+          (firefoxBookmarkNodeToBookmark user)
+          (fromMaybe [] firefoxBookmarkChildren)
+    _ -> pure []
+
+readFirefoxBookmarks :: (MonadIO m) => FilePath -> m (Either String FirefoxBookmarkNode)
+readFirefoxBookmarks fpath =
+  A.eitherDecode' . fromStrict <$> readFile fpath
+
+insertFirefoxBookmarks :: Key User -> FilePath -> DB (Either String Int)
+insertFirefoxBookmarks userId bookmarkFile = do
+  mfmarks <- liftIO $ readFirefoxBookmarks bookmarkFile
+  case mfmarks of
+    Left e -> pure $ Left e
+    Right fmarks -> do
+      bmarks <- liftIO $ firefoxBookmarkNodeToBookmark userId fmarks
+      mapM_ (void . insertUnique) bmarks
+      pure $ Right (length bmarks)

--- a/src/Model/FileNetscape.hs
+++ b/src/Model/FileNetscape.hs
@@ -1,0 +1,209 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Model.FileNetscape where
+
+import ClassyPrelude.Yesod hiding (Value, exists, groupBy, on, (<=.), (==.), (>=.), (||.))
+import Data.Char (isSpace)
+import Data.List (elemIndex, findIndex)
+import Data.Text (breakOn, splitOn, strip)
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Builder as TLB
+import qualified Data.Time.Clock.POSIX as TI (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
+import qualified HTMLEntities.Decoder as HED
+import qualified HTMLEntities.Text as HE
+import Model
+import Model.Custom
+import Types
+
+-- * Netscape Bookmarks
+
+data NetscapeBookmark = NetscapeBookmark
+  { nsbHref :: !Text,
+    nsbTitle :: !Text,
+    nsbDescription :: !Text,
+    nsbTags :: !Text,
+    nsbTime :: !UTCTime
+  }
+  deriving (Eq, Typeable, Ord, Show)
+
+parseNetscapeBookmarks :: Text -> Either String [NetscapeBookmark]
+parseNetscapeBookmarks content = do
+  let links = extractLinks
+  if null links
+    then Left "No bookmarks found"
+    else Right links
+  where
+    -- Extract bookmark links from NETSCAPE-Bookmark-file HTML.
+    -- Split on "<DT>" so each segment corresponds to one entry.  A <DD>
+    -- following the </A> within that same segment is the description for that
+    -- entry (matching the Netscape model: DD belongs to the last seen DT).
+    extractLinks :: [NetscapeBookmark]
+    extractLinks =
+      let dtSegments = drop 1 $ splitOnDT content
+          anchorSegments = filter (\s -> "<A " `isInfixOf` s && "</A>" `isInfixOf` s) dtSegments
+       in catMaybes (_parseNetscapeLink <$> anchorSegments)
+
+    -- Split content into segments at each "<DT>", discarding any text before
+    -- the first marker.
+    splitOnDT :: Text -> [Text]
+    splitOnDT txt =
+      case breakOn "<DT>" txt of
+        (_, "") -> [txt]
+        (before, rest) -> before : splitOnDT (drop 4 rest) -- drop "<DT>" (4 chars)
+
+-- Parse a single <A HREF="..." ...>Title</A> line
+_parseNetscapeLink :: Text -> Maybe NetscapeBookmark
+_parseNetscapeLink line = do
+  guard (("<A " `isInfixOf` line) && ("</A>" `isInfixOf` line))
+  href <- extractAttr "HREF"
+  let lineStr = unpack line
+      aIdx = findIndex (isPrefixOf "<A ") (tails lineStr)
+  case aIdx of
+    Nothing -> Nothing
+    Just idx ->
+      let aTag = drop idx lineStr
+          gtIdx = elemIndex '>' aTag
+       in case gtIdx of
+            Nothing -> Nothing
+            Just gtOffset ->
+              let afterGt = drop (gtOffset + 1) aTag
+                  ltIdx = elemIndex '<' afterGt
+                  titleStr = case ltIdx of
+                    Nothing -> afterGt
+                    Just ltidx -> take ltidx afterGt
+                  title = strip (decodeHtml (pack titleStr))
+               in do
+                    guard (not (null title) && not (null href))
+                    let tags = fromMaybe "" (decodeHtml <$> extractAttr "TAGS")
+                        timeStr = fromMaybe "" (extractAttr "ADD_DATE")
+                        timeInt = readMay timeStr :: Maybe Int
+                        utcTime = maybe (UTCTime (toEnum 0) 0) (TI.posixSecondsToUTCTime . fromIntegral) timeInt
+                    pure
+                      $ NetscapeBookmark
+                        { nsbHref = href,
+                          nsbTitle = title,
+                          nsbDescription = extractDD,
+                          nsbTags = tags,
+                          nsbTime = utcTime
+                        }
+  where
+    -- Extract description text from a <DD> tag that follows </A> in the chunk.
+    extractDD :: Text
+    extractDD =
+      let afterClose = snd (breakOn "</A>" line)
+          afterDD = snd (breakOn "<DD>" afterClose)
+       in if null afterDD
+            then ""
+            else
+              let inner = drop 4 afterDD -- drop "<DD>"
+                  trimmed = fst (breakOn "<" inner)
+                  trimmedStr = dropWhile isSpace . reverse . dropWhile isSpace . reverse . unpack $ trimmed
+               in decodeHtml (pack trimmedStr)
+
+    -- Extract an HTML attribute value (e.g., HREF="value" -> value)
+    extractAttr :: Text -> Maybe Text
+    extractAttr attr =
+      let attrPattern = unpack attr <> "=\""
+          lineStr = unpack line
+       in case dropWhile (\s -> not (attrPattern `isPrefixOf` s)) (tails lineStr) of
+            [] -> Nothing
+            (match : _) ->
+              let afterPattern = drop (length attrPattern) match
+               in case elemIndex '"' afterPattern of
+                    Nothing -> Nothing
+                    Just endIdx ->
+                      let extracted = take endIdx afterPattern
+                       in if null extracted then Nothing else Just (decodeHtml (pack extracted))
+
+    decodeHtml :: Text -> Text
+    decodeHtml = TL.toStrict . TLB.toLazyText . HED.htmlEncodedText
+
+netscapeBookmarkToBookmark :: UserId -> NetscapeBookmark -> IO Bookmark
+netscapeBookmarkToBookmark user NetscapeBookmark {..} = do
+  slug <- mkBmSlug
+  pure
+    $ Bookmark
+      { bookmarkUserId = user,
+        bookmarkSlug = slug,
+        bookmarkHref = nsbHref,
+        bookmarkDescription = nsbTitle,
+        bookmarkExtended = nsbDescription,
+        bookmarkTime = nsbTime,
+        bookmarkShared = True,
+        bookmarkToRead = False,
+        bookmarkSelected = False,
+        bookmarkArchiveHref = Nothing
+      }
+
+bookmarkToNetscapeBookmark :: Bookmark -> Text -> NetscapeBookmark
+bookmarkToNetscapeBookmark Bookmark {..} tags =
+  NetscapeBookmark
+    { nsbHref = bookmarkHref,
+      nsbTitle = bookmarkDescription,
+      nsbDescription = bookmarkExtended,
+      nsbTags = tags,
+      nsbTime = bookmarkTime
+    }
+
+renderNetscapeBookmarks :: [NetscapeBookmark] -> Text
+renderNetscapeBookmarks bmarks =
+  unlines
+    $ [ "<!DOCTYPE NETSCAPE-Bookmark-file-1>",
+        "<META HTTP-EQUIV=\"Content-Type\" CONTENT=\"text/html; charset=UTF-8\">",
+        "<TITLE>Bookmarks</TITLE>",
+        "<H1>Bookmarks</H1>",
+        "<DL><p>"
+      ]
+    <> concatMap renderBookmark bmarks
+    <> ["</DL><p>"]
+  where
+    renderBookmark :: NetscapeBookmark -> [Text]
+    renderBookmark NetscapeBookmark {..} =
+      [ "    <DT><A HREF=\""
+          <> escapeHtml nsbHref
+          <> "\" ADD_DATE=\""
+          <> tshow (floor (TI.utcTimeToPOSIXSeconds nsbTime) :: Int)
+          <> "\" TAGS=\""
+          <> escapeHtml nsbTags
+          <> "\">"
+          <> escapeHtml nsbTitle
+          <> "</A>"
+      ]
+        <> ["    <DD>" <> escapeHtml nsbDescription | not (null (strip nsbDescription))]
+    escapeHtml :: Text -> Text
+    escapeHtml = HE.text
+
+insertNetscapeBookmarks :: Key User -> FilePath -> DB (Either String Int)
+insertNetscapeBookmarks userId bookmarkFile = do
+  meither <- liftIO $ tryAny (readFile bookmarkFile)
+  case meither of
+    Left _ -> pure $ Left "Could not read file"
+    Right (content :: ByteString) ->
+      let contentText = decodeUtf8 content
+       in case parseNetscapeBookmarks contentText of
+            Left e -> pure $ Left e
+            Right nbmarks -> do
+              bmarks <- liftIO $ mapM (netscapeBookmarkToBookmark userId) nbmarks
+              mbids <- mapM insertUnique bmarks
+              mapM_ (void . insertUnique)
+                $ concatMap (uncurry (mkBookmarkTags userId))
+                $ catMaybes
+                $ zipWith
+                  (\mbid nbm -> (,parseNetscapeTags $ nsbTags nbm) <$> mbid)
+                  mbids
+                  nbmarks
+              pure $ Right (length bmarks)
+              where
+                parseNetscapeTags :: Text -> [Text]
+                parseNetscapeTags tagsText =
+                  filter (not . null)
+                    . map strip
+                    $ if ',' `elem` unpack tagsText
+                      then splitOn "," tagsText
+                      else words tagsText
+
+exportNetscapeBookmarks :: Key User -> FilePath -> DB ()
+exportNetscapeBookmarks user fpath = do
+  marks <- allUserBookmarks user
+  let bmarks = fmap (\(bm, t) -> bookmarkToNetscapeBookmark (entityVal bm) t) marks
+  liftIO $ writeFileUtf8 fpath (renderNetscapeBookmarks bmarks)

--- a/src/Model/FileNetscape.hs
+++ b/src/Model/FileNetscape.hs
@@ -73,7 +73,7 @@ _parseNetscapeLink line = do
                     Just ltidx -> take ltidx afterGt
                   title = strip (decodeHtml (pack titleStr))
                in do
-                    guard (not (null title) && not (null href))
+                    guard (not (null href))
                     let tags = fromMaybe "" (decodeHtml <$> extractAttr "TAGS")
                         timeStr = fromMaybe "" (extractAttr "ADD_DATE")
                         timeInt = readMay timeStr :: Maybe Int

--- a/src/Model/FileNote.hs
+++ b/src/Model/FileNote.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Model.FileNote where
+
+import ClassyPrelude.Yesod hiding (Value, exists, groupBy, on, (<=.), (==.), (>=.), (||.))
+import Control.Monad.Fail (MonadFail)
+import qualified Data.Aeson as A
+import qualified Data.Aeson.Types as A (parseFail)
+import Model
+import Model.Custom
+import System.Directory (listDirectory)
+import Types
+
+-- * FileNotes
+
+data FileNote = FileNote
+  { fileNoteId :: !Text,
+    fileNoteTitle :: !Text,
+    fileNoteText :: !Text,
+    fileNoteLength :: !Int,
+    fileNoteCreatedAt :: !UTCTime,
+    fileNoteUpdatedAt :: !UTCTime
+  }
+  deriving (Show, Eq, Typeable, Ord)
+
+instance FromJSON FileNote where
+  parseJSON (Object o) =
+    FileNote
+      <$> o
+        .: "id"
+      <*> o
+        .: "title"
+      <*> o
+        .: "text"
+      <*> o
+        .: "length"
+      <*> (readFileNoteTime =<< o .: "created_at")
+      <*> (readFileNoteTime =<< o .: "updated_at")
+  parseJSON _ = A.parseFail "bad parse"
+
+instance ToJSON FileNote where
+  toJSON FileNote {..} =
+    object
+      [ "id" .= toJSON fileNoteId,
+        "title" .= toJSON fileNoteTitle,
+        "text" .= toJSON fileNoteText,
+        "length" .= toJSON fileNoteLength,
+        "created_at" .= toJSON (showFileNoteTime fileNoteCreatedAt),
+        "updated_at" .= toJSON (showFileNoteTime fileNoteUpdatedAt)
+      ]
+
+readFileNoteTime ::
+  (MonadFail m) =>
+  String -> m UTCTime
+readFileNoteTime = parseTimeM True defaultTimeLocale "%F %T"
+
+showFileNoteTime :: UTCTime -> String
+showFileNoteTime = formatTime defaultTimeLocale "%F %T"
+
+fileNoteToNote :: UserId -> FileNote -> IO Note
+fileNoteToNote user FileNote {..} = do
+  slug <- mkNtSlug
+  pure $
+    Note
+      { noteUserId = user,
+        noteSlug = slug,
+        noteLength = fileNoteLength,
+        noteTitle = fileNoteTitle,
+        noteText = fileNoteText,
+        noteIsMarkdown = False,
+        noteShared = False,
+        noteCreated = fileNoteCreatedAt,
+        noteUpdated = fileNoteUpdatedAt
+      }
+
+insertDirFileNotes :: Key User -> FilePath -> DB (Either String Int)
+insertDirFileNotes userId noteDirectory = do
+  mfnotes <- liftIO $ readFileNotes noteDirectory
+  case mfnotes of
+    Left e -> pure $ Left e
+    Right fnotes -> do
+      notes <- liftIO $ mapM (fileNoteToNote userId) fnotes
+      void $ mapM insertUnique notes
+      pure $ Right (length notes)
+  where
+    readFileNotes :: (MonadIO m) => FilePath -> m (Either String [FileNote])
+    readFileNotes fdir = do
+      files <- liftIO (listDirectory fdir)
+      noteBSS <- mapM (readFile . (fdir </>)) files
+      pure (mapM (A.eitherDecode' . fromStrict) noteBSS)

--- a/src/Model/Form.hs
+++ b/src/Model/Form.hs
@@ -1,0 +1,174 @@
+module Model.Form where
+
+import ClassyPrelude.Yesod hiding (Value, exists, groupBy, on, (<=.), (==.), (>=.), (||.))
+import qualified ClassyPrelude.Yesod as CP
+import qualified Data.Aeson as A
+import Database.Esqueleto.Experimental hiding ((<&>))
+import Model
+import Model.Custom
+import Types
+
+-- * AccountSettingsForm
+
+data AccountSettingsForm = AccountSettingsForm
+  { _privateDefault :: Bool,
+    _archiveDefault :: Bool,
+    _suggestTags :: Bool,
+    _privacyLock :: Bool,
+    _archiveBackendEnabled :: Bool
+  }
+  deriving (Show, Eq, Read, Generic)
+
+instance FromJSON AccountSettingsForm where parseJSON = A.genericParseJSON gDefaultFormOptions
+
+instance ToJSON AccountSettingsForm where toJSON = A.genericToJSON gDefaultFormOptions
+
+toAccountSettingsForm :: Bool -> User -> AccountSettingsForm
+toAccountSettingsForm archiveBackendEnabled User {..} =
+  AccountSettingsForm
+    { _privateDefault = userPrivateDefault,
+      _archiveDefault = userArchiveDefault,
+      _suggestTags = userSuggestTags,
+      _privacyLock = userPrivacyLock,
+      _archiveBackendEnabled = archiveBackendEnabled
+    }
+
+updateUserFromAccountSettingsForm :: Key User -> AccountSettingsForm -> DB ()
+updateUserFromAccountSettingsForm userId AccountSettingsForm {..} =
+  CP.update
+    userId
+    [ UserPrivateDefault CP.=. _privateDefault,
+      UserArchiveDefault CP.=. _archiveDefault,
+      UserSuggestTags CP.=. _suggestTags,
+      UserPrivacyLock CP.=. _privacyLock
+    ]
+
+-- BookmarkForm
+
+data BookmarkForm = BookmarkForm
+  { _url :: Text,
+    _title :: Maybe Text,
+    _description :: Maybe Textarea,
+    _tags :: Maybe Text,
+    _private :: Maybe Bool,
+    _toread :: Maybe Bool,
+    _bid :: Maybe Int64,
+    _slug :: Maybe BmSlug,
+    _selected :: Maybe Bool,
+    _time :: Maybe UTCTimeStr,
+    _archiveUrl :: Maybe Text
+  }
+  deriving (Show, Eq, Read, Generic)
+
+instance FromJSON BookmarkForm where parseJSON = A.genericParseJSON gDefaultFormOptions
+
+instance ToJSON BookmarkForm where toJSON = A.genericToJSON gDefaultFormOptions
+
+gDefaultFormOptions :: A.Options
+gDefaultFormOptions = A.defaultOptions {A.fieldLabelModifier = drop 1}
+
+toBookmarkFormList :: [(Entity Bookmark, Maybe Text)] -> [BookmarkForm]
+toBookmarkFormList = fmap _toBookmarkForm'
+
+_toBookmarkForm :: (Entity Bookmark, [Entity BookmarkTag]) -> BookmarkForm
+_toBookmarkForm (bm, tags) =
+  _toBookmarkForm' (bm, Just $ unwords $ fmap (bookmarkTagTag . entityVal) tags)
+
+_toBookmarkForm' :: (Entity Bookmark, Maybe Text) -> BookmarkForm
+_toBookmarkForm' (Entity bid Bookmark {..}, tags) =
+  BookmarkForm
+    { _url = bookmarkHref,
+      _title = Just bookmarkDescription,
+      _description = Just $ Textarea $ bookmarkExtended,
+      _tags = Just $ fromMaybe "" tags,
+      _private = Just $ not bookmarkShared,
+      _toread = Just bookmarkToRead,
+      _bid = Just $ fromSqlKey $ bid,
+      _slug = Just bookmarkSlug,
+      _selected = Just bookmarkSelected,
+      _time = Just $ UTCTimeStr $ bookmarkTime,
+      _archiveUrl = bookmarkArchiveHref
+    }
+
+_toBookmark :: UserId -> BookmarkForm -> IO Bookmark
+_toBookmark userId BookmarkForm {..} = do
+  time <- liftIO getCurrentTime
+  slug <- maybe mkBmSlug pure _slug
+  pure $
+    Bookmark
+      { bookmarkUserId = userId,
+        bookmarkSlug = slug,
+        bookmarkHref = _url,
+        bookmarkDescription = fromMaybe "" _title,
+        bookmarkExtended = maybe "" unTextarea _description,
+        bookmarkTime = maybe time unUTCTimeStr _time,
+        bookmarkShared = maybe True not _private,
+        bookmarkToRead = Just True == _toread,
+        bookmarkSelected = Just True == _selected,
+        bookmarkArchiveHref = _archiveUrl
+      }
+
+data TagSuggestionRequest = TagSuggestionRequest
+  { _query :: Text,
+    _currentTags :: Maybe [Text]
+  }
+  deriving (Show, Eq, Read, Generic)
+
+data TagSuggestionResponse = TagSuggestionResponse
+  { _suggestions :: [Suggestion]
+  }
+  deriving (Show, Eq, Read, Generic)
+
+data Suggestion = Suggestion
+  { _term :: Text,
+    _count :: Int
+  }
+  deriving (Show, Eq, Read, Generic)
+
+instance FromJSON TagSuggestionRequest where parseJSON = A.genericParseJSON gDefaultFormOptions
+
+instance ToJSON TagSuggestionRequest where toJSON = A.genericToJSON gDefaultFormOptions
+
+instance FromJSON TagSuggestionResponse where parseJSON = A.genericParseJSON gDefaultFormOptions
+
+instance ToJSON TagSuggestionResponse where toJSON = A.genericToJSON gDefaultFormOptions
+
+instance FromJSON Suggestion where parseJSON = A.genericParseJSON gDefaultFormOptions
+
+instance ToJSON Suggestion where toJSON = A.genericToJSON gDefaultFormOptions
+
+getTagSuggestions :: Key User -> TagSuggestionRequest -> Int -> DB TagSuggestionResponse
+getTagSuggestions user TagSuggestionRequest {_query = query, _currentTags = currentTags} top = do
+  values <-
+    fmap (bimap unValue unValue)
+      <$> ( select $ do
+              (tag, countRows', matchPriority) <- from suggestionsQuery
+              orderBy [asc matchPriority, desc countRows', asc $ lower_ tag]
+              limit (fromIntegral top)
+              pure (tag, countRows')
+          )
+  pure
+    TagSuggestionResponse
+      { _suggestions = uncurry Suggestion <$> values
+      }
+  where
+    excludedTags = take 400 $ map toLower (fromMaybe ([] :: [Text]) currentTags)
+
+    suggestionsQuery = do
+      t <- from (table @BookmarkTag)
+      where_
+        ( t
+            ^. BookmarkTagUserId
+            ==. val user
+            &&. (lower_ (t ^. BookmarkTagTag) `like` lower_ ((%) ++. val query ++. (%)))
+        )
+      unless (null excludedTags) $ where_ $ not_ (lower_ (t ^. BookmarkTagTag) `in_` valList excludedTags)
+      let countRows' = countRows
+          matchPriority =
+            case_
+              [ when_ (lower_ (t ^. BookmarkTagTag) ==. lower_ (val query)) then_ (val (0 :: Int)),
+                when_ (lower_ (t ^. BookmarkTagTag) `like` lower_ (val query ++. (%))) then_ (val (1 :: Int))
+              ]
+              (else_ (val (2 :: Int)))
+      groupBy (lower_ (t ^. BookmarkTagTag))
+      pure (t ^. BookmarkTagTag, countRows', matchPriority)


### PR DESCRIPTION
- Extend migration to add commands: `importnetscapebookmarks`, `exportnetscapebookmarks` (fixes #30)
- fix migration command `ImportBookmarks` (pinboard import file) parsing bug to handle when the description is a boolean (fixes #32)
- tag suggestions: when a tag exactly matches an existing tag, it will appear first in the suggestion list